### PR TITLE
Version to use the refresh token mechanism since generated tokens via…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 #IDE
 .vscode/
+*.iml
+*.idea
 
 #Virtual enviroment
 .venv/

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 COPY requirements.txt /root
 RUN pip install -r /root/requirements.txt
 # Define default dropbox folder in docker
-ENV DROPBOX_TOKEN=""
+ENV DROPBOX_APP_KEY=""
+ENV DROPBOX_APP_SECRET=""
+ENV DROPBOX_REFRESH_TOKEN=""
 ENV DROPBOX_FOLDER="/"
 ENV DROPBOX_ROOTDIR="/dropbox"
 

--- a/README.md
+++ b/README.md
@@ -12,20 +12,24 @@ If you add in your root a file `.dropboxignore` you can select witch type of fil
 ## Start with docker
 To use this docker is really easy:
 1. Create your [App in dropbox](https://www.dropbox.com/developers/reference/getting-started#app%20console)
-2. Generated access token
+2. Generated refresh token by using `init_dropbox_refreshToken.sh` script. 
 3. Pull this docker
 ```
 docker pull rbonghi/dropbox
 ```
 4. Run your docker
 ```
-docker run -e DROPBOX_TOKEN=<WRITE YOUR TOKEN HERE> -v <FOLDER YOU WANT SYNC>:/dropbox dropbox
+docker run \
+-e DROPBOX_APP_KEY=<WRITE YOUR APPLICATION KEY HERE> \
+-e DROPBOX_APP_SECRET=<WRITE YOUR APPLICATION SECRET HERE> \
+-e DROPBOX_REFRESH_TOKEN=<WRITE YOUR REFRESH TOKEN HERE>  \
+-v <FOLDER YOU WANT SYNC>:/dropbox rbonghi/dropbox
 ```
 
 ## Start with docker-compose
 How to start up the docker-dropbox app machine:
 1. Create your [App in dropbox](https://www.dropbox.com/developers/reference/getting-started#app%20console)
-2. Generated access token
+2. Generated refresh token by using `init_dropbox_refreshToken.sh` script.
 3. Write your docker-compose.yml file or add:
 ```yml
 version: '3'
@@ -34,11 +38,13 @@ services:
     image: rbonghi/dropbox:latest
     environment:
       - PYTHONUNBUFFERED=1
-      - DROPBOX_TOKEN=<WRITE YOUR TOKEN HERE>
+      - DROPBOX_APP_KEY=<WRITE YOUR APPLICATION KEY HERE>
+      - DROPBOX_APP_SECRET=<WRITE YOUR APPLICATION SECRET HERE>
+      - DROPBOX_REFRESH_TOKEN=<WRITE YOUR REFRESH TOKEN HERE>
     volumes:
       - <FOLDER YOU WANT SYNC>:/dropbox
 ```
-4. start your docker:
+4. Start your docker:
 ```
 docker-compose up
 ```
@@ -63,7 +69,9 @@ services:
     command: ["--fromDropbox", "-i", "120"]
     environment:
       - PYTHONUNBUFFERED=1
-      - DROPBOX_TOKEN=<WRITE YOUR TOKEN HERE>
+      - DROPBOX_APP_KEY=<WRITE YOUR APPLICATION KEY HERE>
+      - DROPBOX_APP_SECRET=<WRITE YOUR APPLICATION SECRET HERE>
+      - DROPBOX_REFRESH_TOKEN=<WRITE YOUR REFRESH TOKEN HERE>
     volumes:
       - <FOLDER YOU WANT SYNC>:/dropbox
 ```
@@ -71,12 +79,18 @@ services:
 # Start without docker
 If you want launch this script without start a docker container:
 ```
-python DropboxSync.py <DROPBOX_FOLDER> <ROOT_FOLDER> --token <WRITE YOUR TOKEN HERE> [options]
+python dbsync \ 
+--rootdir <ROOT_FOLDER> \
+--folder <DROPBOX_FOLDER> \
+--appKey <WRITE YOUR APP KEY HERE> \
+--appSecret <WRITE YOUR APP SECRET HERE> \
+[options]
 ```
 For `[options]`:
 * **--verbose** Show in detail all steps for each sync
 * **--fromLocal** or **--fromDropbox** Read [Configuration](#configuration)
 * **--interval** [default=60s] The Interval to sync from Dropbox in **--fromDropbox** mode
+* **--refreshToken** Set the refresh token retrieved and logged in the console at first launch or via the init_script. (This will avoid the manual acceptation step via a generated access code in the navigator)
 
 # Make manifest for amd64 and arm
 Use this manifest for multi architect version

--- a/dbsync/__main__.py
+++ b/dbsync/__main__.py
@@ -26,7 +26,7 @@ import sys
 import os
 import time
 # Package imports
-from updown import UpDown
+from dbsync import UpDown
 
 # Create logger for jplotlib
 logger = logging.getLogger(__name__)
@@ -83,7 +83,7 @@ def main():
     logging.basicConfig(level=level, format='%(name)s - %(levelname)s - %(message)s')
     # Check token
     if not (args.appKey and args.appSecret):
-        print(f"{bcolors.FAIL}app key, app secret and refresh token must be set{bcolors.ENDC}")
+        print(f"{bcolors.FAIL}app key and app secret must be set{bcolors.ENDC}")
         sys.exit(2)
 
     # Check folders

--- a/init_dropbox_refreshToken.sh
+++ b/init_dropbox_refreshToken.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+echo  "Enter APP_KEY:" 
+read APP_KEY
+
+echo  "Enter APP_SECRET:" 
+read APP_SECRET
+BASIC_AUTH=$(echo -n "$APP_KEY":"$APP_SECRET" | base64)
+
+echo "Navigate to URL and get ACCESS CODE"
+echo "https://www.dropbox.com/oauth2/authorize?client_id=$APP_KEY&token_access_type=offline&response_type=code"
+
+echo "Enter the ACCESS_CODE:" 
+read ACCESS_CODE_GENERATED
+
+curl --location --request POST 'https://api.dropboxapi.com/oauth2/token' \
+--header "Authorization: Basic $BASIC_AUTH" \
+--header 'Content-Type: application/x-www-form-urlencoded' \
+--data-urlencode "code=$ACCESS_CODE_GENERATED" \
+--data-urlencode 'grant_type=authorization_code'


### PR DESCRIPTION
This is a modified version to use the refresh token mechanism since dropbox removed the ability to generate some in their app console interface.
So if we want long-lived token, we now have to use a refresh tokenand there is not interface in dropbox app console to do it.

So in this commit :
* In case of run in cli mode (python dbync ...) things are automated, user just has to input the access code by following the url provided. App will then run by using refresh token retrieved via dropbox API (and print it for further use) 
* In case of docker run, user will have to generate it manually by using provided script and then set as environment variable. I also added appKey and appSecret which are required to refresh the token after the 4 hours ttl of regular token.

Hope this can help people like me just wanting some dropbox sync via one Application and not the full account sync.
