### PR TITLE
Cast interval to int and change python_requires

### DIFF
--- a/dbsync/updown.py
+++ b/dbsync/updown.py
@@ -95,7 +95,7 @@ class UpDown(Thread, PatternMatchingEventHandler):
         self.db_folder = dbfolder
         self.folder = folder
         self.dropboxignore = dropboxignore
-        self.interval = interval
+        self.interval = int(interval)
         self.overwrite = overwrite
 
         if not refresh_token:

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ setup(
     install_requires=requirements,
     # Requisites
     # https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires
-    python_requires='>=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4',
+    python_requires='>=3.0, !=3.1, !=3.2, !=3.3, <4',
     platforms=["linux", "linux2", "darwin"],
     # Zip safe configuration
     # https://setuptools.readthedocs.io/en/latest/setuptools.html#setting-the-zip-safe-flag


### PR DESCRIPTION
This change fixes the following issue for me. It first happened on a Ubuntu Server within Docker but I could also replicate it locally on NixOS. 

```
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/nix/store/0l539chjmcq5kdd43j6dgdjky4sjl7hl-python3-3.12.8/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
    self.run()
  File "/home/rick/tmp/docker-dropbox-app/.venv/lib/python3.12/site-packages/dbsync-1.0.0-py3.12.egg/dbsync/updown.py", line 115, in run
    while not self.stopped.wait(self.interval):
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/0l539chjmcq5kdd43j6dgdjky4sjl7hl-python3-3.12.8/lib/python3.12/threading.py", line 655, in wait
    signaled = self._cond.wait(timeout)
               ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/0l539chjmcq5kdd43j6dgdjky4sjl7hl-python3-3.12.8/lib/python3.12/threading.py", line 358, in wait
    if timeout > 0:
       ^^^^^^^^^^^
TypeError: '>' not supported between instances of 'str' and 'int'
```

I believe the cast to int is straightforward but I'm unsure about the change in python_requires versions - that's just something needed to run it at all. Let me know if that change is not needed.

## Summary by Sourcery

This pull request fixes a TypeError and relaxes the `python_requires` specification. The TypeError was caused by comparing a string to an integer when setting the thread wait interval. The `python_requires` specification was relaxed to allow versions like 3.10 and above.

Bug Fixes:
- Fixes a TypeError caused by comparing a string to an integer when setting the thread wait interval.

Enhancements:
- Relax the `python_requires` specification in `setup.py` to allow versions like 3.10 and above.